### PR TITLE
chore: disable dependabot auto-rebase to prevent retry loops

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    rebase-strategy: "disabled"
     reviewers:
       - "yahgwai"
     labels:


### PR DESCRIPTION
## Summary
- Disable Dependabot auto-rebase strategy to stop excessive workflow runs
- Dependabot was running every 1-2 minutes instead of weekly as configured
- This was happening because PRs with conflicts were being constantly rebased

## Problem
- The ethers v5 to v6 upgrade PR has peer dependency conflicts
- Dependabot keeps trying to rebase it, creating a retry loop
- This consumes unnecessary GitHub Actions minutes

## Solution
- Set `rebase-strategy: "disabled"` in dependabot.yml
- Dependabot will still create PRs but won't auto-rebase on conflicts
- This should restore the expected weekly update schedule

## Test plan
- [x] Verify dependabot.yml syntax is valid
- [ ] Monitor Dependabot activity after merge to confirm retry loop stops
