### PR TITLE
fix: skip git hooks setup in CI environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "release:minor": "npm run prerelease && npm test && npm run clean && standard-version --release-as minor && ./publish.sh",
     "release:major": "npm run prerelease && npm test && npm run clean && standard-version --release-as major && ./publish.sh",
     "release:first": "npm run prerelease && npm test && npm run clean && standard-version --first-release && ./publish.sh",
-    "postinstall": "./.githooks/setup.sh"
+    "postinstall": "./scripts/postinstall.sh"
   },
   "keywords": [
     "ethereum",

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Postinstall script that skips git hooks setup in CI environments
+
+# Check if we're in a CI environment
+if [ "$CI" = "true" ] || [ "$CONTINUOUS_INTEGRATION" = "true" ] || [ "$GITHUB_ACTIONS" = "true" ]; then
+  echo "CI environment detected - skipping git hooks setup"
+  exit 0
+fi
+
+# Run git hooks setup for local development
+./.githooks/setup.sh


### PR DESCRIPTION
## Summary
- Added CI-aware postinstall script that skips git hooks setup in CI environments
- Prevents unnecessary git configuration during automated builds

## Changes
- Created `scripts/postinstall.sh` that checks for CI environment variables (CI, CONTINUOUS_INTEGRATION, GITHUB_ACTIONS)
- Updated package.json postinstall script to use the new CI-aware script
- Git hooks setup still runs normally in local development environments

## Test plan
- [x] Tested locally - postinstall runs git hooks setup as expected
- [ ] CI tests will verify that postinstall doesn't fail in GitHub Actions