### PR TITLE
ci: use RELEASE_TOKEN for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Need full history for standard-version
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.RELEASE_TOKEN }}
     
     - uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
## Summary
- Switch from GITHUB_TOKEN to RELEASE_TOKEN in release workflow to enable bypassing branch protection rules for automated version bumps

## Test plan
- [ ] Verify RELEASE_TOKEN secret is added to repository settings
- [ ] Confirm the user associated with RELEASE_TOKEN is added to ruleset bypass list
- [ ] Test that the release workflow can push version bumps directly to main