### PR TITLE
fix: configure git to use RELEASE_TOKEN for pushing to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
+        # Ensure the RELEASE_TOKEN is used for pushes
+        git remote set-url origin https://x-access-token:${{ secrets.RELEASE_TOKEN }}@github.com/${{ github.repository }}.git
     
     - run: npm ci
     
@@ -94,7 +96,7 @@ jobs:
     # Push commits and tags
     - name: Push changes
       run: |
-        # The checkout action configures git to use the token
+        # Use the RELEASE_TOKEN to bypass branch protection
         git push --follow-tags origin main
     
     # Create GitHub release using gh CLI (matches manual process)


### PR DESCRIPTION
## Summary
- Configured the release workflow to explicitly use RELEASE_TOKEN for git push operations to bypass branch protection rules

## Test plan
- The workflow will be tested when the next release is triggered
- Verify that the release workflow can successfully push commits and tags to the main branch