### PR TITLE
fix: use GitHub App token instead of PAT for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,17 @@ jobs:
       contents: write
       id-token: write
     steps:
+    # Generate token from GitHub App
+    - uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+    
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Need full history for standard-version
-        token: ${{ secrets.RELEASE_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
     
     - uses: actions/setup-node@v4
       with:
@@ -47,8 +54,6 @@ jobs:
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        # Ensure the RELEASE_TOKEN is used for pushes
-        git remote set-url origin https://x-access-token:${{ secrets.RELEASE_TOKEN }}@github.com/${{ github.repository }}.git
     
     - run: npm ci
     
@@ -96,13 +101,13 @@ jobs:
     # Push commits and tags
     - name: Push changes
       run: |
-        # Use the RELEASE_TOKEN to bypass branch protection
+        # GitHub App token will bypass branch protection
         git push --follow-tags origin main
     
     # Create GitHub release using gh CLI (matches manual process)
     - name: Create GitHub Release
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         VERSION="${{ steps.version.outputs.VERSION }}"
         gh release create "v$VERSION" \


### PR DESCRIPTION
## Summary
- Replace RELEASE_TOKEN (PAT) with GitHub App token generation
- This allows the release workflow to bypass branch protection rules without giving your personal account bypass permissions

## Changes
- Added GitHub App token generation step
- Updated checkout to use app token
- Updated git push to use app token (configured via checkout)
- Updated GitHub release creation to use app token

## Test plan
- The workflow will be tested on the next release
- Verify the GitHub App can successfully push commits, tags, and create releases