### PR TITLE
Enable all skipped test suites

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -6,7 +6,7 @@ import {
   validateConfig,
 } from '../src/config';
 
-describe.skip('Configuration System', () => {
+describe('Configuration System', () => {
   // Store original env vars to restore after tests
   const originalEnv = { ...process.env };
 

--- a/tests/connectivity.test.ts
+++ b/tests/connectivity.test.ts
@@ -1,6 +1,6 @@
 import { testProvider, usdcContract, USDC_ADDRESS, TEST_FROM_BLOCK } from './setup';
 
-describe.skip('Test Environment Connectivity', () => {
+describe('Test Environment Connectivity', () => {
   test('should connect to hardhat fork', async () => {
     const network = await testProvider.getNetwork();
     expect(network.chainId).toBe(31337); // Hardhat local network chain ID

--- a/tests/error-handling-simple.test.ts
+++ b/tests/error-handling-simple.test.ts
@@ -1,7 +1,7 @@
 import { GenericEventFetcher } from '../src/fetcher';
 import { DEFAULT_CONFIG, validateConfig } from '../src/config';
 
-describe.skip('Error Handling - Simple Tests', () => {
+describe('Error Handling - Simple Tests', () => {
   it('should validate configuration errors correctly', () => {
     expect(() => {
       new GenericEventFetcher({

--- a/tests/fetcher.test.ts
+++ b/tests/fetcher.test.ts
@@ -3,7 +3,7 @@ import { DEFAULT_CONFIG } from '../src/config';
 import { FetcherConfig } from '../types/interfaces';
 import { ConfigurationError } from '../src/errors';
 
-describe.skip('GenericEventFetcher', () => {
+describe('GenericEventFetcher', () => {
   describe('constructor', () => {
     test('should initialize with default config when no config provided', () => {
       const fetcher = new GenericEventFetcher();

--- a/tests/integration-basic.test.ts
+++ b/tests/integration-basic.test.ts
@@ -10,7 +10,7 @@ interface TestEvent extends RawEvent {
   args: any;
 }
 
-describe.skip('Integration - Basic Event Fetching', () => {
+describe('Integration - Basic Event Fetching', () => {
   let fetcher: GenericEventFetcher<TestEvent, any>;
   let provider: ethers.providers.JsonRpcProvider;
   let usdcContract: ContractInterface;

--- a/tests/parallel-oop.test.ts
+++ b/tests/parallel-oop.test.ts
@@ -27,7 +27,7 @@ jest.mock('p-limit', () => {
   });
 });
 
-describe.skip('TaskQueue', () => {
+describe('TaskQueue', () => {
   let taskQueue: TaskQueue<string>;
 
   beforeEach(() => {
@@ -98,7 +98,7 @@ describe.skip('TaskQueue', () => {
   });
 });
 
-describe.skip('ParallelExecutor', () => {
+describe('ParallelExecutor', () => {
   let executor: ParallelExecutor<string>;
   let mockTasks: TaskFunction<string>[];
   let onProgressMock: jest.Mock;
@@ -332,7 +332,7 @@ describe.skip('ParallelExecutor', () => {
   });
 });
 
-describe.skip('Integration with executeInParallel', () => {
+describe('Integration with executeInParallel', () => {
   test('should maintain backward compatibility', async () => {
     const { executeInParallel } = await import('../src/utils/parallel');
 

--- a/tests/retryable-provider.test.ts
+++ b/tests/retryable-provider.test.ts
@@ -2,7 +2,7 @@ import { RetryableProvider } from '../src/utils/retryable-provider';
 import { ProviderError, RateLimitError } from '../src/errors';
 import { ethers } from 'ethers';
 
-describe.skip('RetryableProvider', () => {
+describe('RetryableProvider', () => {
   let originalSend: any;
   let originalPerform: any;
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -11,7 +11,7 @@ jest.mock('p-limit', () => {
   });
 });
 
-describe.skip('Parallel Utils', () => {
+describe('Parallel Utils', () => {
   describe('createBlockRangeChunks', () => {
     test('should create correct chunks for block ranges', () => {
       const chunks = createBlockRangeChunks(100, 200, 50);
@@ -163,7 +163,7 @@ describe.skip('Parallel Utils', () => {
   });
 });
 
-describe.skip('Provider Utils', () => {
+describe('Provider Utils', () => {
   describe('createProvider', () => {
     test('should throw error when no URL provided', async () => {
       await expect(createProvider({})).rejects.toThrow(ProviderError);


### PR DESCRIPTION
## Summary
- Re-enabled all 11 test suites that were previously marked as skipped using `describe.skip()`
- All tests now pass successfully without any modifications required
- Improves test coverage and ensures comprehensive validation of the library

## Test plan
- [x] Removed `.skip` from all test files as specified in issue #17
- [x] Verified each test file individually passes
- [x] Ran full test suite with `npm test` - all 108 tests pass
- [x] No test logic modifications were needed - tests were already functional